### PR TITLE
フォロワー取得APIを変更

### DIFF
--- a/functions/src/api/getFollowers.ts
+++ b/functions/src/api/getFollowers.ts
@@ -3,7 +3,7 @@ import { firestore } from '../modules/firebase';
 import { env } from '../utils/env';
 import { checkInvalidToken, setTokenInvalid, getToken, setWatch, setUserResult, checkProtectedUser, setUserResultWithNoChange } from '../utils/firestore';
 import { UserData } from '../utils/interfaces';
-import { getFollowersList } from '../utils/twitter';
+import { getFollowersIdList } from '../utils/twitter';
 
 export default async () => {
   const now = new Date();
@@ -52,7 +52,7 @@ export default async () => {
       access_token_secret: twitterAccessTokenSecret,
     });
 
-    const result = await getFollowersList(client, {
+    const result = await getFollowersIdList(client, {
       userId: twitterId,
       cursor: nextCursor,
     });
@@ -69,10 +69,8 @@ export default async () => {
       return;
     }
 
-    const { users, next_cursor_str: newNextCursor } = result.response;
-    const followers = users.map(({ id_str }) => id_str);
-
-    const watchId = await setWatch(snapshot.id, followers, now, currentWatchesId);
+    const { ids, next_cursor_str: newNextCursor } = result.response;
+    const watchId = await setWatch(snapshot.id, ids, now, currentWatchesId);
     await setUserResult(snapshot.id, watchId, newNextCursor, now);
 
     return {

--- a/functions/src/utils/twitter.ts
+++ b/functions/src/utils/twitter.ts
@@ -92,7 +92,7 @@ export interface GetUsersLookupProps {
 /**
  * ユーザー情報を取得
  * 100人まで 取得可能
- * 15分につき 900回 実行可能
+ * 15分につき 300回 実行可能
  */
 export const getUsersLookupSingle = (
   client: Twitter,


### PR DESCRIPTION
## 経緯
フォロワーが多いとその分だけ処理が分散していた
フォロワーの取得 `getFollowers` は ユーザーIDのみ必要とするので、 
`followers/list` は宝の持ち腐れだった

## API

### [旧API followers/list](https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list)

- 15分に 3,000人しか取れない
- ユーザーの詳細情報が取れる

### [新API followers/ids](https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids)

- 15分に 75,000人も取れる
- ユーザーのIDのみ取れる
