### PR TITLE
refactor(functions): separate firebase utils from main handlers

### DIFF
--- a/packages/functions/src/api/getFollowers.ts
+++ b/packages/functions/src/api/getFollowers.ts
@@ -1,7 +1,6 @@
-import { UserData } from '@yukukuru/types';
-import { firestore } from '../modules/firebase';
 import { setUserResult } from '../utils/firestore/users/setUserResult';
 import { setUserResultWithNoChange } from '../utils/firestore/users/setUserResultWithNoChange';
+import { tmpGetTargetsToGetFollowers } from '../utils/firestore/users/tmpGetTargetsToGetFollowers';
 import { addWatch } from '../utils/firestore/users/watches/addWatch';
 import { getToken } from '../utils/firestore/tokens/getToken';
 import { setTokenInvalid } from '../utils/firestore/tokens/setTokenInvalid';
@@ -9,60 +8,17 @@ import { getFollowersIds } from '../utils/twitter/getFollowersIds';
 import { checkInvalidToken, checkProtectedUser } from '../utils/twitter/error';
 import { TwitterAccessToken } from '../utils/twitter/generateClient';
 
-export default async () => {
+export default async (): Promise<void> => {
   const now = new Date();
-  // API は 15分で 75000人 の取得制限がある
-  // 1回で 10000人 まで取れるので、2.5分間隔
-  // 余裕を見て 3分間隔
-  const time3 = new Date();
-  time3.setMinutes(now.getMinutes() - 3);
+  const targets = await tmpGetTargetsToGetFollowers();
 
-  const time15 = new Date();
-  time15.setMinutes(now.getMinutes() - 15);
+  const requests = targets.map(async (doc) => {
+    const { nextCursor } = doc.data;
 
-  const allUsers = firestore
-    .collection('users')
-    .where('active', '==', true)
-    .where('invalid', '==', false)
-    .where('lastUpdated', '<', time15)
-    .orderBy('lastUpdated')
-    .limit(100)
-    .get();
-
-  const pausedUsers = firestore
-    .collection('users')
-    .where('active', '==', true)
-    .where('invalid', '==', false)
-    .where('pausedGetFollower', '==', true)
-    .where('lastUpdated', '<', time3)
-    .orderBy('lastUpdated')
-    .limit(10)
-    .get();
-
-  const newUsers = firestore
-    .collection('users')
-    .where('active', '==', true)
-    .where('invalid', '==', false)
-    .where('newUser', '==', true)
-    .limit(10)
-    .get();
-
-  const [allUsersSnap, pausedUsersSnap, newUsersSnap] = await Promise.all([allUsers, pausedUsers, newUsers]);
-  const docs = [...allUsersSnap.docs, ...pausedUsersSnap.docs, ...newUsersSnap.docs].filter(
-    (x, i, self) => self.findIndex((y) => x.id === y.id) === i
-  );
-  console.log(
-    docs.map((doc) => doc.id),
-    docs.length
-  );
-
-  const requests = docs.map(async (snapshot) => {
-    const { nextCursor } = snapshot.data() as UserData;
-
-    const token = await getToken(snapshot.id);
+    const token = await getToken(doc.id);
     if (!token) {
-      console.log(snapshot.id, 'no-token');
-      await setTokenInvalid(snapshot.id);
+      console.log(doc.id, 'no-token');
+      await setTokenInvalid(doc.id);
       return;
     }
     const { twitterAccessToken, twitterAccessTokenSecret, twitterId } = token;
@@ -79,17 +35,17 @@ export default async () => {
     });
 
     if (result.errors.length) {
-      console.error(snapshot.id, result.errors);
+      console.error(doc.id, result.errors);
 
       const invalidToken = checkInvalidToken(result.errors);
       const protectedUser = checkProtectedUser(result.errors);
 
       if (invalidToken) {
-        await setTokenInvalid(snapshot.id);
+        await setTokenInvalid(doc.id);
       }
 
       if (protectedUser) {
-        await setUserResultWithNoChange(snapshot.id, now);
+        await setUserResultWithNoChange(doc.id, now);
       }
       if (invalidToken || protectedUser) {
         return;
@@ -104,11 +60,11 @@ export default async () => {
     }
 
     const ended = newNextCursor === '0' || newNextCursor === '-1';
-    const watchId = await addWatch(snapshot.id, ids, now, ended);
-    await setUserResult(snapshot.id, watchId, newNextCursor, now);
+    const watchId = await addWatch(doc.id, ids, now, ended);
+    await setUserResult(doc.id, watchId, newNextCursor, now);
 
     return {
-      userId: snapshot.id,
+      userId: doc.id,
       watchId,
       newNextCursor,
     };

--- a/packages/functions/src/handlers/updateToken.ts
+++ b/packages/functions/src/handlers/updateToken.ts
@@ -1,14 +1,14 @@
 import { TokenData } from '@yukukuru/types';
 import * as functions from 'firebase-functions';
-import { firestore } from '../modules/firebase';
+import { setToken } from '../utils/firestore/tokens/setToken';
 
 type Props = TokenData;
 
-function isObject(data: any): data is Record<string, any> {
+function isObject(data: unknown): data is Record<string, any> {
   return typeof data === 'object' && data !== null && !Array.isArray(data);
 }
 
-function isProps(data: any): data is Props {
+function isProps(data: unknown): data is Props {
   return (
     isObject(data) &&
     typeof data.twitterAccessToken === 'string' &&
@@ -18,14 +18,13 @@ function isProps(data: any): data is Props {
   );
 }
 
-export async function updateTokenHandler(data: any, context: functions.https.CallableContext) {
+export async function updateTokenHandler(data: unknown, context: functions.https.CallableContext): Promise<boolean> {
   console.log('updateToken', data, context);
 
   if (!isProps(data) || typeof context.auth === 'undefined') {
     return false;
   }
 
-  await firestore.collection('tokens').doc(context.auth.uid).set(data);
-
+  await setToken(context.auth.uid, data);
   return true;
 }

--- a/packages/functions/src/utils/firestore/tokens/setToken.ts
+++ b/packages/functions/src/utils/firestore/tokens/setToken.ts
@@ -1,0 +1,8 @@
+import { TokenData } from '@yukukuru/types';
+import { firestore } from '../../../modules/firebase';
+
+const collection = firestore.collection('tokens');
+
+export const setToken = async (userId: string, token: TokenData): Promise<void> => {
+  await collection.doc(userId).set(token, { merge: true });
+};

--- a/packages/functions/src/utils/firestore/users/tmpGetTargetsToGetFollowers.ts
+++ b/packages/functions/src/utils/firestore/users/tmpGetTargetsToGetFollowers.ts
@@ -1,0 +1,52 @@
+import { UserData, FirestoreIdData } from '@yukukuru/types';
+import { firestore } from '../../../modules/firebase';
+
+export const tmpGetTargetsToGetFollowers = async (): Promise<FirestoreIdData<UserData>[]> => {
+  const now = new Date();
+  // API は 15分で 75000人 の取得制限がある
+  // 1回で 10000人 まで取れるので、2.5分間隔
+  // 余裕を見て 3分間隔
+  const time3 = new Date(now.getTime() - 3 * 60 * 1000);
+  const time15 = new Date(now.getTime() - 15 * 60 * 1000);
+
+  const allUsers = firestore
+    .collection('users')
+    .where('active', '==', true)
+    .where('invalid', '==', false)
+    .where('lastUpdated', '<', time15)
+    .orderBy('lastUpdated')
+    .limit(100)
+    .get();
+
+  const pausedUsers = firestore
+    .collection('users')
+    .where('active', '==', true)
+    .where('invalid', '==', false)
+    .where('pausedGetFollower', '==', true)
+    .where('lastUpdated', '<', time3)
+    .orderBy('lastUpdated')
+    .limit(10)
+    .get();
+
+  const newUsers = firestore
+    .collection('users')
+    .where('active', '==', true)
+    .where('invalid', '==', false)
+    .where('newUser', '==', true)
+    .limit(10)
+    .get();
+
+  const [allUsersSnap, pausedUsersSnap, newUsersSnap] = await Promise.all([allUsers, pausedUsers, newUsers]);
+  const docs = [...allUsersSnap.docs, ...pausedUsersSnap.docs, ...newUsersSnap.docs].filter(
+    (x, i, self) => self.findIndex((y) => x.id === y.id) === i
+  );
+  console.log(
+    docs.map((doc) => doc.id),
+    docs.length
+  );
+
+  return docs.map((doc) => ({
+    id: doc.id,
+    data: doc.data() as UserData,
+  }));
+};

--- a/packages/functions/src/utils/firestore/users/tmpGetTargetsToUpdateTwUsers.ts
+++ b/packages/functions/src/utils/firestore/users/tmpGetTargetsToUpdateTwUsers.ts
@@ -1,0 +1,22 @@
+import { UserData, FirestoreIdData } from '@yukukuru/types';
+import { firestore } from '../../../modules/firebase';
+
+export const tmpGetTargetsToUpdateTwUsers = async (): Promise<FirestoreIdData<UserData>[]> => {
+  const now = new Date();
+  const time1week = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  const qs = await firestore
+    .collection('users')
+    .where('active', '==', true)
+    .where('invalid', '==', false)
+    .where('newUser', '==', false)
+    .where('lastUpdatedTwUsers', '<', time1week)
+    .orderBy('lastUpdatedTwUsers')
+    .limit(50)
+    .get();
+
+  return qs.docs.map((doc) => ({
+    id: doc.id,
+    data: doc.data() as UserData,
+  }));
+};

--- a/packages/functions/src/utils/firestore/users/watches/getLastWatch.ts
+++ b/packages/functions/src/utils/firestore/users/watches/getLastWatch.ts
@@ -1,0 +1,17 @@
+import { WatchData } from '@yukukuru/types';
+import { firestore } from '../../../../modules/firebase';
+
+export const getLastWatch = async (id: string): Promise<WatchData | null> => {
+  const qs = await firestore
+    .collection('users')
+    .doc(id)
+    .collection('watches')
+    .orderBy('getEndDate', 'desc')
+    .limit(1)
+    .get();
+  if (qs.docs.length < 1) {
+    return null;
+  }
+  const doc = qs.docs[0];
+  return doc.data() as WatchData;
+};


### PR DESCRIPTION
- firestore への処理を utils に逃がす