### PR TITLE
feat(functions): add group field on user, change interval to run getFollowers 

### DIFF
--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.149",
     "@types/twitter": "^1.7.0",
-    "@yukukuru/types": "file:./yukukuru-types-0.2.0.tgz",
+    "@yukukuru/types": "file:./yukukuru-types-0.2.1.tgz",
     "eslint": "^6.8.0",
     "typescript": "^3.8.3"
   }

--- a/packages/functions/src/api/getFollowers.ts
+++ b/packages/functions/src/api/getFollowers.ts
@@ -3,23 +3,21 @@ import { firestore } from '../modules/firebase';
 import { addQueuesTypeGetFollowers } from '../utils/firestore/queues/addQueuesTypeGetFollowers';
 
 export default async (): Promise<void> => {
-  const now = new Date();
-  // API は 15分で 75000人 の取得制限がある
-  // 1回で 10000人 まで取れるので、2.5分間隔
-  // 余裕を見て 3分間隔
-  const time3 = new Date();
-  time3.setMinutes(now.getMinutes() - 3);
+  const now = new Date(Math.floor(new Date().getTime() / (60 * 1000)) * 60 * 1000);
+  const group = now.getMinutes() % 15;
 
-  const time15 = new Date();
-  time15.setMinutes(now.getMinutes() - 15);
+  // 15分前
+  const time15 = new Date(now.getTime() - 14 * 60 * 1000);
+  // 60分前
+  const time60 = new Date(now.getTime() - 59 * 60 * 1000);
 
   const allUsers = firestore
     .collection('users')
     .where('active', '==', true)
     .where('invalid', '==', false)
-    .where('lastUpdated', '<', time15)
-    .orderBy('lastUpdated')
-    .limit(100)
+    .where('pausedGetFollower', '==', false)
+    .where('lastUpdated', '<', time60)
+    .where('group', '==', group)
     .get();
 
   const pausedUsers = firestore
@@ -27,9 +25,8 @@ export default async (): Promise<void> => {
     .where('active', '==', true)
     .where('invalid', '==', false)
     .where('pausedGetFollower', '==', true)
-    .where('lastUpdated', '<', time3)
-    .orderBy('lastUpdated')
-    .limit(10)
+    .where('lastUpdated', '<', time15)
+    .where('group', '==', group)
     .get();
 
   const newUsers = firestore
@@ -37,7 +34,6 @@ export default async (): Promise<void> => {
     .where('active', '==', true)
     .where('invalid', '==', false)
     .where('newUser', '==', true)
-    .limit(10)
     .get();
 
   const [allUsersSnap, pausedUsersSnap, newUsersSnap] = await Promise.all([allUsers, pausedUsers, newUsers]);

--- a/packages/functions/src/api/getFollowers.ts
+++ b/packages/functions/src/api/getFollowers.ts
@@ -2,7 +2,7 @@ import { FirestoreIdData, UserData, QueueTypeGetFollowersData } from '@yukukuru/
 import { firestore } from '../modules/firebase';
 import { addQueuesTypeGetFollowers } from '../utils/firestore/queues/addQueuesTypeGetFollowers';
 
-export default async () => {
+export default async (): Promise<void> => {
   const now = new Date();
   // API は 15分で 75000人 の取得制限がある
   // 1回で 10000人 まで取れるので、2.5分間隔

--- a/packages/functions/src/api/updateTwUsers.ts
+++ b/packages/functions/src/api/updateTwUsers.ts
@@ -22,7 +22,7 @@ export default async () => {
 
   const usersId: string[] = [];
   const requests = querySnapshot.docs.map(async (snapshot) => {
-    const watch = await snapshot.ref.collection('watches').orderBy('getEndDate').limit(1).get();
+    const watch = await snapshot.ref.collection('watches').orderBy('getEndDate', 'desc').limit(1).get();
     if (watch.size !== 1) {
       return '';
     }

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -21,13 +21,15 @@ const functionsRuntimeOptions: functions.RuntimeOptions = {
   memory: '1GB',
 };
 
-export const getFollowers = builder.runWith(httpsRuntimeOptions).https.onRequest(async (req, res) => {
-  if (req.query.key !== env.http_functions_key) {
-    res.status(403).end();
-    return;
-  }
-  await getFollowersHandler();
-  res.status(200).end();
+export const getFollowers = builder.runWith(httpsRuntimeOptions).https.onRequest((req, res) => {
+  (async (): Promise<void> => {
+    if (req.query.key !== env.http_functions_key) {
+      res.status(403).end();
+      return;
+    }
+    await getFollowersHandler();
+    res.status(200).end();
+  })();
 });
 
 export const updateTwUsers = builder.runWith(httpsRuntimeOptions).https.onRequest(async (req, res) => {

--- a/packages/functions/src/utils/firestore/users.ts
+++ b/packages/functions/src/utils/firestore/users.ts
@@ -1,5 +1,6 @@
 import { FirestoreDateLike, UserData } from '@yukukuru/types';
 import { firestore, admin } from '../../modules/firebase';
+import { getGroupIndex } from '../group';
 
 const collection = firestore.collection('users');
 
@@ -18,6 +19,7 @@ export async function initializeUser(id: string, props: Pick<UserData, 'photoUrl
     nextCursor: '-1',
     currentWatchesId: '',
     pausedGetFollower: false,
+    group: getGroupIndex(id),
     ...props,
   };
   await collection.doc(id).set(data, { merge: true });

--- a/packages/functions/src/utils/group.ts
+++ b/packages/functions/src/utils/group.ts
@@ -1,0 +1,27 @@
+const groups = [
+  ['a', 'b', 'c', 'd'],
+  ['e', 'f', 'g', 'h'],
+  ['i', 'j', 'k', 'l'],
+  ['m', 'n', 'o', 'p'],
+  ['q', 'r', 's', 't'],
+  ['u', 'v', 'w', 'x'],
+  ['y', 'z', 'A', 'B'],
+  ['C', 'D', 'E', 'F'],
+  ['G', 'H', 'I', 'J'],
+  ['K', 'L', 'M', 'N'],
+  ['O', 'P', 'Q', 'R'],
+  ['S', 'T', 'U', 'V'],
+  ['W', 'X', 'Y', 'Z'],
+  ['0', '1', '2', '3', '4'],
+  ['5', '6', '7', '8', '9'],
+];
+
+/**
+ * ID からグループ番号を返す
+ * 0-14 の 15種類の番号
+ */
+export const getGroupIndex = (id: string): number => {
+  const char = id.slice(0, 1);
+  const index = groups.findIndex((group) => group.includes(char));
+  return Math.min(Math.max(index, 0), 14);
+};

--- a/packages/functions/yarn.lock
+++ b/packages/functions/yarn.lock
@@ -344,9 +344,9 @@
     "@types/node" "*"
     "@types/request" "*"
 
-"@yukukuru/types@file:./yukukuru-types-0.2.0.tgz":
-  version "0.2.0"
-  resolved "file:./yukukuru-types-0.2.0.tgz"
+"@yukukuru/types@file:./yukukuru-types-0.2.1.tgz":
+  version "0.2.1"
+  resolved "file:./yukukuru-types-0.2.1.tgz"
   dependencies:
     "@firebase/firestore-types" "^1.10.1"
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yukukuru/types",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint types --ext .ts,.js"

--- a/packages/types/types/firestore/user.d.ts
+++ b/packages/types/types/firestore/user.d.ts
@@ -31,4 +31,7 @@ export interface UserData<T extends FirestoreDateLike = Timestamp> {
 
   /** フォロワー一覧取得 state 途中かどうか */
   pausedGetFollower: boolean;
+
+  /** グループ番号 0-14 のいずれか */
+  group: number;
 }


### PR DESCRIPTION
- UIDの頭文字によって15種類のグループを作成
- getFollowers の処理を 1時間おきに変更 (2回目以降の取得は15分おき)
- 実行時刻の分の値によって、処理を走らせるユーザーを決定する
- ユーザー数の制限は設けず、グループに所属する全員に処理をかける