### PR TITLE
refactor records.ts with useReducer

### DIFF
--- a/packages/yukukuru-app/src/store/database/records.ts
+++ b/packages/yukukuru-app/src/store/database/records.ts
@@ -37,37 +37,39 @@ const getRecordsFromFirestore = async (
 };
 
 type State = {
-  isFirstLoading: boolean
-  isNextLoading: boolean
-  isLoaded: boolean
-}
+  isFirstLoading: boolean;
+  isNextLoading: boolean;
+  isLoaded: boolean;
+};
 
 const initialState: State = {
   isFirstLoading: false,
   isNextLoading: false,
   isLoaded: false,
-}
+};
 
-type Action = {
-  type: 'getRecordStarted'
-  payload?: { isNext: boolean }
-} |  {
-  type: 'getRecordSuccess'
-}
+type Action =
+  | {
+      type: 'getRecordStarted';
+      payload?: { isNext: boolean };
+    }
+  | {
+      type: 'getRecordSuccess';
+    };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'getRecordStarted': {
-      return { ...state, isFirstLoading: true, isNextLoading: !!action.payload?.isNext }
+      return { ...state, isFirstLoading: true, isNextLoading: !!action.payload?.isNext };
     }
     case 'getRecordSuccess': {
-      return { ...state, isLoaded: true, isFirstLoading: false, isNextLoading: false }
+      return { ...state, isLoaded: true, isFirstLoading: false, isNextLoading: false };
     }
   }
 }
 
 const useRecords = () => {
-  const [state, dispatch] = useReducer(reducer, initialState)
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   /** 続きのデータがあるかどうか */
   const [hasNext, setHasNext] = useState<boolean>(true);
@@ -95,17 +97,17 @@ const useRecords = () => {
     setHasNext(size >= 50);
     setCursor(size > 0 ? docs[size - 1] : null);
 
-    dispatch({type: 'getRecordSuccess'})
+    dispatch({ type: 'getRecordSuccess' });
   }, [cursor, uid]);
 
   /**
    * 初回 Records を取得する
    */
   useEffect(() => {
-    if(state.isFirstLoading || state.isLoaded || !uid) {
+    if (state.isFirstLoading || state.isLoaded || !uid) {
       return;
     }
-    dispatch({type: 'getRecordStarted'})
+    dispatch({ type: 'getRecordStarted' });
     getRecords();
   }, [getRecords, state.isFirstLoading, state.isLoaded, uid]);
 
@@ -116,7 +118,7 @@ const useRecords = () => {
     if (state.isNextLoading || !uid) {
       return;
     }
-    dispatch({type: 'getRecordStarted', payload: { isNext: true }})
+    dispatch({ type: 'getRecordStarted', payload: { isNext: true } });
     getRecords();
   };
 

--- a/packages/yukukuru-app/src/store/database/records.ts
+++ b/packages/yukukuru-app/src/store/database/records.ts
@@ -50,8 +50,8 @@ const initialState: State = {
 
 type Action =
   | {
-      type: 'getRecordStarted';
-      payload?: { isNext: boolean };
+      type: 'getRecordStart';
+      payload: { isNext: boolean };
     }
   | {
       type: 'getRecordSuccess';
@@ -59,8 +59,8 @@ type Action =
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
-    case 'getRecordStarted': {
-      return { ...state, isFirstLoading: true, isNextLoading: !!action.payload?.isNext };
+    case 'getRecordStart': {
+      return { ...state, isFirstLoading: !action.payload.isNext, isNextLoading: action.payload.isNext };
     }
     case 'getRecordSuccess': {
       return { ...state, isLoaded: true, isFirstLoading: false, isNextLoading: false };
@@ -107,7 +107,7 @@ const useRecords = () => {
     if (state.isFirstLoading || state.isLoaded || !uid) {
       return;
     }
-    dispatch({ type: 'getRecordStarted' });
+    dispatch({ type: 'getRecordStart', payload: { isNext: false } });
     getRecords();
   }, [getRecords, state.isFirstLoading, state.isLoaded, uid]);
 
@@ -118,7 +118,7 @@ const useRecords = () => {
     if (state.isNextLoading || !uid) {
       return;
     }
-    dispatch({ type: 'getRecordStarted', payload: { isNext: true } });
+    dispatch({ type: 'getRecordStart', payload: { isNext: true } });
     getRecords();
   };
 

--- a/packages/yukukuru-app/src/store/database/records.ts
+++ b/packages/yukukuru-app/src/store/database/records.ts
@@ -1,5 +1,5 @@
 import { FirestoreIdData, RecordData, RecordDataOld } from '@yukukuru/types';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useReducer } from 'react';
 import { createContainer } from 'unstated-next';
 import firebase, { firestore } from '../../modules/firebase';
 import { convertRecordsForView } from '../../utils/records';
@@ -36,15 +36,38 @@ const getRecordsFromFirestore = async (
   return qs;
 };
 
+type State = {
+  isFirstLoading: boolean
+  isNextLoading: boolean
+  isLoaded: boolean
+}
+
+const initialState: State = {
+  isFirstLoading: false,
+  isNextLoading: false,
+  isLoaded: false,
+}
+
+type Action = {
+  type: 'getRecordStarted'
+  payload?: { isNext: boolean }
+} |  {
+  type: 'getRecordSuccess'
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'getRecordStarted': {
+      return { ...state, isFirstLoading: true, isNextLoading: !!action.payload?.isNext }
+    }
+    case 'getRecordSuccess': {
+      return { ...state, isLoaded: true, isFirstLoading: false, isNextLoading: false }
+    }
+  }
+}
+
 const useRecords = () => {
-  /** 最初のデータが読み込み中かどうか */
-  const [isFirstLoading, setFirstLoading] = useState<boolean>(false);
-
-  /** 最初のデータの読み込みが完了しているかどうか */
-  const [isFirstLoaded, setFirstLoaded] = useState<boolean>(false);
-
-  /** 続きのデータが読み込み中かどうか */
-  const [isNextLoading, setNextLoading] = useState<boolean>(false);
+  const [state, dispatch] = useReducer(reducer, initialState)
 
   /** 続きのデータがあるかどうか */
   const [hasNext, setHasNext] = useState<boolean>(true);
@@ -72,40 +95,37 @@ const useRecords = () => {
     setHasNext(size >= 50);
     setCursor(size > 0 ? docs[size - 1] : null);
 
-    // この順番でないと初回Records取得が再始動する
-    setFirstLoaded(true);
-    setFirstLoading(false);
-    setNextLoading(false);
+    dispatch({type: 'getRecordSuccess'})
   }, [cursor, uid]);
 
   /**
    * 初回 Records を取得する
    */
   useEffect(() => {
-    if (isFirstLoading || isFirstLoaded || !uid) {
+    if(state.isFirstLoading || state.isLoaded || !uid) {
       return;
     }
-    setFirstLoading(true);
+    dispatch({type: 'getRecordStarted'})
     getRecords();
-  }, [getRecords, isFirstLoading, isFirstLoaded, uid]);
+  }, [getRecords, state.isFirstLoading, state.isLoaded, uid]);
 
   /**
    * 続きの Records を取得する
    */
   const getNextRecords = () => {
-    if (isNextLoading || !uid) {
+    if (state.isNextLoading || !uid) {
       return;
     }
-    setNextLoading(true);
+    dispatch({type: 'getRecordStarted', payload: { isNext: true }})
     getRecords();
   };
 
   return {
     /** 最初のデータが読み込み中かどうか */
-    isLoading: isFirstLoading || !isFirstLoaded,
+    isLoading: state.isFirstLoading || !state.isLoaded,
 
     /** 続きのデータが読み込み中かどうか */
-    isNextLoading,
+    isNextLoading: state.isNextLoading,
 
     /** アイテム */
     items,


### PR DESCRIPTION
自己満でやってみました。
動作確認してないので動かないかもです。

本当はuseReducer 使うならすべてのstate をuseReducerのstateにしちゃうべきだと思いますが、とりあえずわかりやすいisFirstLoading, isFirstLoaded, isNextLoading だけuseReducer 化してみました。

良い点としては
- stateを変更するロジックがreducer にまとまること。
- useEffect内で何回も setHoge() する必要がなくなること
  - async関数内でsetHoge() 何回もやると、旧75行目のコメントにも書いてあるようにstate変更処理がatomic に行えない欠点があると思います(ていうかamotaraoさんのコード見て初めて僕もそう思いました)


